### PR TITLE
Fix handling of failed requests in Cognitive provider

### DIFF
--- a/wagtailaltgenerator/providers/cognitive.py
+++ b/wagtailaltgenerator/providers/cognitive.py
@@ -30,7 +30,7 @@ def describe_by_url(image_url):
     )
 
     if response.status_code != 200:
-        logging.warn([response, response.data])
+        logger.warning([response, response.text])
         return None
 
     return response.json()
@@ -50,7 +50,7 @@ def describe_by_data(image_data):
     )
 
     if response.status_code != 200:
-        logging.warn([response, response.data])
+        logger.warning([response, response.text])
         return None
 
     data = response.json()


### PR DESCRIPTION
Hi!

Noticed a small bug - if a request to Cognitive fails, the app tries to log it, but an exception is raised because the `response` object has no `data` attribute. 

```
  File "/wagtailaltgenerator/signals.py", line 33, in apply_image_alt
    result = provider.describe(instance)
  File "/wagtailaltgenerator/providers/cognitive.py", line 68, in describe
    data = describe_by_data(image_data)
  File "/wagtailaltgenerator/providers/cognitive.py", line 53, in describe_by_data
    logging.warn([response, response.data])
AttributeError: 'Response' object has no attribute 'data'
```

This patch changes it to log the response text instead. It also changes to use the namespaced logger defined at the top of the module.