### PR TITLE
Improve image url handling with external storage

### DIFF
--- a/wagtailaltgenerator/providers/cognitive.py
+++ b/wagtailaltgenerator/providers/cognitive.py
@@ -6,7 +6,7 @@ import requests
 
 from wagtailaltgenerator import app_settings
 from wagtailaltgenerator.providers import AbstractProvider, DescriptionResult
-from wagtailaltgenerator.utils import get_image_data, get_local_image_data
+from wagtailaltgenerator.utils import get_image_data, get_local_image_data, get_original_rendition
 
 
 API_URL = "https://{}.api.cognitive.microsoft.com"
@@ -61,13 +61,15 @@ class Cognitive(AbstractProvider):
     def describe(self, image):
         if app_settings.ALT_GENERATOR_PREFER_UPLOAD:
             if not image.is_stored_locally():
-                image_data = get_image_data(image.file.url)
+                rendition = get_original_rendition(image)
+                image_data = get_image_data(rendition.url)
                 data = describe_by_data(image_data)
             else:
                 image_data = get_local_image_data(image.file)
                 data = describe_by_data(image_data)
         else:
-            data = describe_by_url(image.file.url)
+            rendition = get_original_rendition(image)
+            data = describe_by_url(rendition.url)
 
         description = None
         tags = []

--- a/wagtailaltgenerator/providers/google_vision.py
+++ b/wagtailaltgenerator/providers/google_vision.py
@@ -6,7 +6,7 @@ from oauth2client.client import GoogleCredentials
 
 from wagtailaltgenerator import app_settings
 from wagtailaltgenerator.providers import AbstractProvider, DescriptionResult
-from wagtailaltgenerator.utils import get_image_data, get_local_image_data
+from wagtailaltgenerator.utils import get_image_data, get_local_image_data, get_original_rendition
 
 
 class GoogleVision(AbstractProvider):
@@ -17,7 +17,8 @@ class GoogleVision(AbstractProvider):
 
     def describe(self, image):
         if not image.is_stored_locally():
-            image_data = get_image_data(image.file.url)
+            rendition = get_original_rendition(image)
+            image_data = get_image_data(rendition.url)
         else:
             image_data = get_local_image_data(image.file)
 

--- a/wagtailaltgenerator/providers/rekognition.py
+++ b/wagtailaltgenerator/providers/rekognition.py
@@ -4,7 +4,7 @@ import boto3
 
 from wagtailaltgenerator import app_settings
 from wagtailaltgenerator.providers import AbstractProvider, DescriptionResult
-from wagtailaltgenerator.utils import get_image_data, get_local_image_data
+from wagtailaltgenerator.utils import get_image_data, get_local_image_data, get_original_rendition
 
 
 class Rekognition(AbstractProvider):
@@ -14,7 +14,8 @@ class Rekognition(AbstractProvider):
 
     def describe(self, image):
         if not image.is_stored_locally():
-            image_data = get_image_data(image.file.url)
+            rendition = get_original_rendition(image)
+            image_data = get_image_data(rendition.url)
         else:
             image_data = get_local_image_data(image.file)
 

--- a/wagtailaltgenerator/utils.py
+++ b/wagtailaltgenerator/utils.py
@@ -1,10 +1,19 @@
 import os
-
 import requests
+
 from django.utils.translation import get_language
 
 from wagtailaltgenerator.translation_providers import get_current_provider
 from wagtailaltgenerator.providers import DescriptionResult
+
+
+def get_original_rendition(image):
+    """
+    Returns the original image rendition. Needed to get the correct image URL for processing
+    when using external storage (such as S3)
+    """
+    from wagtail.images.shortcuts import get_rendition_or_not_found
+    return get_rendition_or_not_found(image, 'original')
 
 
 def get_image_data(image_url):


### PR DESCRIPTION
we use django-storages with the `s3boto3` storage backend.

S3 is configured with `AWS_DEFAULT_ACL = "private"`, with only `MEDIA_ROOT`/images|documents being exposed to the public.

Alt generation fails because `image.file.url` points to `S3_URL/original_images/filename.ext` (thus under ACL restrictions) whereas `S3_URL/images/filename.original.ext` (the rendition folder) works well. Note this the latter is also the URL seen on the edit page under "File".